### PR TITLE
Filter out directories when listing Shrine folder contents

### DIFF
--- a/lib/eikon/video_processor.rb
+++ b/lib/eikon/video_processor.rb
@@ -37,7 +37,7 @@ module Eikon
     sig { params(folder_path: String).returns(T::Array[T::Hash[String, T.any(Integer, String)]]) }
     def get_frames_dhash(folder_path)
       # All the file lists start with `.` and `..` so we need to remove those
-      file_names = Dir.entries(folder_path).drop(2)
+      file_names = Dir.entries(folder_path).filter { |entry| entry.start_with?(".") == false }
 
       dhashes = file_names.map do |file_name|
         dhash = Eikon.dhash_for_image("#{folder_path}/#{file_name}")

--- a/lib/eikon/video_processor.rb
+++ b/lib/eikon/video_processor.rb
@@ -36,8 +36,8 @@ module Eikon
 
     sig { params(folder_path: String).returns(T::Array[T::Hash[String, T.any(Integer, String)]]) }
     def get_frames_dhash(folder_path)
-      # All the file lists start with `.` and `..` so we need to remove those
-      file_names = Dir.entries(folder_path).filter { |entry| entry.start_with?(".") == false }
+      # Filter the '.' and '..' directories from the current directory's file list
+      file_names = Dir.entries(folder_path).filter { |entry| entry.start_with?(".") }
 
       dhashes = file_names.map do |file_name|
         dhash = Eikon.dhash_for_image("#{folder_path}/#{file_name}")


### PR DESCRIPTION
This PR resolves a bug in which Eikon's `VideoProcessor` would sometimes recognize `.` and `..`  as video frame image files and try to hash them. 